### PR TITLE
Add missing tests for 12 make commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,14 +41,14 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "illuminate/console": "^10.0|^11.0|^12.0",
         "illuminate/support": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.10",
         "nunomaduro/larastan": "^2.0|^3.0",
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^8.5|^9.0|^10.0",
         "phpunit/phpunit": "^9.4|^10.1|^11.5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     "require-dev": {
         "laravel/pint": "^1.10",
         "nunomaduro/larastan": "^2.0|^3.0",
-        "orchestra/testbench": "^8.5|^9.0|^10.0",
+        "orchestra/testbench": "^8.37|^9.0|^10.0",
         "phpunit/phpunit": "^9.4|^10.1|^11.5"
     }
 }

--- a/src/Console/Commands/ModuleMakeComponentCommand.php
+++ b/src/Console/Commands/ModuleMakeComponentCommand.php
@@ -16,10 +16,10 @@ class ModuleMakeComponentCommand extends ModuleMakerCommand
                         {name : The name of the component}
                         {--module= : Name of module controller should belong to}
                         {--inline : Create a component that renders an inline view}
-                        {--view: Create an anonymous component with only a view}
+                        {--view : Create an anonymous component with only a view}
                         {--test : Generate an accompanying PHPUnit test for the Component}
                         {--pest : Generate an accompanying Pest test for the Component}
-                        {--force|f : Create the class even if the component already exists}';
+                        {--force : Create the class even if the component already exists}';
 
     /**
      * The console command description.
@@ -42,10 +42,8 @@ class ModuleMakeComponentCommand extends ModuleMakerCommand
         $folder = $this->getFolderPath();
 
         $name = $this->qualifyClass($module.'\\'.$folder.'\\'.$filename);
-        $path = $this->getPath($name);
-        if ($this->files->exists($path) && ! $this->option('force')) {
-            $this->logFileExist($name);
 
+        if (! $path = $this->getFilePath(name: $name, force: $this->option('force'))) {
             return true;
         }
 

--- a/src/Console/Commands/ModuleMakeListenerCommand.php
+++ b/src/Console/Commands/ModuleMakeListenerCommand.php
@@ -37,7 +37,7 @@ class ModuleMakeListenerCommand extends ModuleMakerCommand
         $filename = Str::studly($this->getNameInput());
         $folder = $this->getFolderPath();
 
-        $name = $this->qualifyClass('Modules\\'.$module.'\\'.$folder.'\\'.$filename);
+        $name = $this->qualifyClass($module.'\\'.$folder.'\\'.$filename);
 
         if (! $path = $this->getFilePath($name)) {
             return true;

--- a/src/Console/Commands/ModuleMakeProviderCommand.php
+++ b/src/Console/Commands/ModuleMakeProviderCommand.php
@@ -50,7 +50,7 @@ class ModuleMakeProviderCommand extends ModuleMakerCommand
 
         $this->logFileCreated($name);
 
-        return true;
+        return null;
     }
 
     protected function getFolderPath(): string

--- a/src/Console/Commands/ModuleMakerCommand.php
+++ b/src/Console/Commands/ModuleMakerCommand.php
@@ -3,6 +3,7 @@
 namespace NorbyBaru\Modularize\Console\Commands;
 
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Str;
 
 abstract class ModuleMakerCommand extends GeneratorCommand
@@ -45,7 +46,7 @@ abstract class ModuleMakerCommand extends GeneratorCommand
      *
      * @param  string  $name
      *
-     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     * @throws FileNotFoundException
      */
     protected function buildClass($name): string
     {

--- a/tests/Commands/MakeComponentCommandTest.php
+++ b/tests/Commands/MakeComponentCommandTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace NorbyBaru\Modularize\Tests\Commands;
+
+use NorbyBaru\Modularize\Tests\MakeCommandTestCase;
+
+class MakeComponentCommandTest extends MakeCommandTestCase
+{
+    public function test_it_should_create_a_component()
+    {
+        $this->artisan(
+            command: 'module:make:component',
+            parameters: [
+                'name' => 'UserCard',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Components/UserCard.php');
+    }
+
+    public function test_it_should_create_a_component_with_force_option()
+    {
+        $this->artisan(
+            command: 'module:make:component',
+            parameters: [
+                'name' => 'UserCard',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Components/UserCard.php');
+
+        $this->artisan(
+            command: 'module:make:component',
+            parameters: [
+                'name' => 'UserCard',
+                '--module' => $this->moduleName,
+                '--force' => true,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Components/UserCard.php');
+    }
+
+    public function test_it_should_fail_to_create_component_on_duplicate_filename()
+    {
+        $this->artisan(
+            command: 'module:make:component',
+            parameters: [
+                'name' => 'UserCard',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Components/UserCard.php');
+
+        $this->artisan(
+            command: 'module:make:component',
+            parameters: [
+                'name' => 'UserCard',
+                '--module' => $this->moduleName,
+            ]
+        )->assertFailed();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Components/UserCard.php');
+    }
+}
+

--- a/tests/Commands/MakeComponentCommandTest.php
+++ b/tests/Commands/MakeComponentCommandTest.php
@@ -66,4 +66,3 @@ class MakeComponentCommandTest extends MakeCommandTestCase
         $this->assertFileExists(filename: $this->getModulePath().'/Components/UserCard.php');
     }
 }
-

--- a/tests/Commands/MakeEventCommandTest.php
+++ b/tests/Commands/MakeEventCommandTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NorbyBaru\Modularize\Tests\Commands;
+
+use NorbyBaru\Modularize\Tests\MakeCommandTestCase;
+
+class MakeEventCommandTest extends MakeCommandTestCase
+{
+    public function test_it_should_create_an_event()
+    {
+        $this->artisan(
+            command: 'module:make:event',
+            parameters: [
+                'name' => 'SendEmails',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Events/SendEmails.php');
+    }
+
+    public function test_it_should_fail_to_create_event_on_duplicate_filename()
+    {
+        $this->artisan(
+            command: 'module:make:event',
+            parameters: [
+                'name' => 'SendEmails',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Events/SendEmails.php');
+
+        $this->artisan(
+            command: 'module:make:event',
+            parameters: [
+                'name' => 'SendEmails',
+                '--module' => $this->moduleName,
+            ]
+        )->assertFailed();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Events/SendEmails.php');
+    }
+}

--- a/tests/Commands/MakeJobCommandTest.php
+++ b/tests/Commands/MakeJobCommandTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NorbyBaru\Modularize\Tests\Commands;
+
+use NorbyBaru\Modularize\Tests\MakeCommandTestCase;
+
+class MakeJobCommandTest extends MakeCommandTestCase
+{
+    public function test_it_should_create_a_job()
+    {
+        $this->artisan(
+            command: 'module:make:job',
+            parameters: [
+                'name' => 'ProcessPodcast',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Jobs/ProcessPodcast.php');
+    }
+
+    public function test_it_should_fail_to_create_job_on_duplicate_filename()
+    {
+        $this->artisan(
+            command: 'module:make:job',
+            parameters: [
+                'name' => 'ProcessPodcast',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Jobs/ProcessPodcast.php');
+
+        $this->artisan(
+            command: 'module:make:job',
+            parameters: [
+                'name' => 'ProcessPodcast',
+                '--module' => $this->moduleName,
+            ]
+        )->assertFailed();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Jobs/ProcessPodcast.php');
+    }
+}

--- a/tests/Commands/MakeListenerCommandTest.php
+++ b/tests/Commands/MakeListenerCommandTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NorbyBaru\Modularize\Tests\Commands;
+
+use NorbyBaru\Modularize\Tests\MakeCommandTestCase;
+
+class MakeListenerCommandTest extends MakeCommandTestCase
+{
+    public function test_it_should_create_a_listener()
+    {
+        $this->artisan(
+            command: 'module:make:listener',
+            parameters: [
+                'name' => 'SendEmailsListener',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Listeners/SendEmailsListener.php');
+    }
+
+    public function test_it_should_fail_to_create_listener_on_duplicate_filename()
+    {
+        $this->artisan(
+            command: 'module:make:listener',
+            parameters: [
+                'name' => 'SendEmailsListener',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Listeners/SendEmailsListener.php');
+
+        $this->artisan(
+            command: 'module:make:listener',
+            parameters: [
+                'name' => 'SendEmailsListener',
+                '--module' => $this->moduleName,
+            ]
+        )->assertFailed();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Listeners/SendEmailsListener.php');
+    }
+}

--- a/tests/Commands/MakeMiddlewareCommandTest.php
+++ b/tests/Commands/MakeMiddlewareCommandTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NorbyBaru\Modularize\Tests\Commands;
+
+use NorbyBaru\Modularize\Tests\MakeCommandTestCase;
+
+class MakeMiddlewareCommandTest extends MakeCommandTestCase
+{
+    public function test_it_should_create_a_middleware()
+    {
+        $this->artisan(
+            command: 'module:make:middleware',
+            parameters: [
+                'name' => 'CheckUserRole',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Middleware/CheckUserRole.php');
+    }
+
+    public function test_it_should_fail_to_create_middleware_on_duplicate_filename()
+    {
+        $this->artisan(
+            command: 'module:make:middleware',
+            parameters: [
+                'name' => 'CheckUserRole',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Middleware/CheckUserRole.php');
+
+        $this->artisan(
+            command: 'module:make:middleware',
+            parameters: [
+                'name' => 'CheckUserRole',
+                '--module' => $this->moduleName,
+            ]
+        )->assertFailed();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Middleware/CheckUserRole.php');
+    }
+}

--- a/tests/Commands/MakeNotificationCommandTest.php
+++ b/tests/Commands/MakeNotificationCommandTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NorbyBaru\Modularize\Tests\Commands;
+
+use NorbyBaru\Modularize\Tests\MakeCommandTestCase;
+
+class MakeNotificationCommandTest extends MakeCommandTestCase
+{
+    public function test_it_should_create_a_notification()
+    {
+        $this->artisan(
+            command: 'module:make:notification',
+            parameters: [
+                'name' => 'UserRegistered',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Notifications/UserRegistered.php');
+    }
+
+    public function test_it_should_fail_to_create_notification_on_duplicate_filename()
+    {
+        $this->artisan(
+            command: 'module:make:notification',
+            parameters: [
+                'name' => 'UserRegistered',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Notifications/UserRegistered.php');
+
+        $this->artisan(
+            command: 'module:make:notification',
+            parameters: [
+                'name' => 'UserRegistered',
+                '--module' => $this->moduleName,
+            ]
+        )->assertFailed();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Notifications/UserRegistered.php');
+    }
+}

--- a/tests/Commands/MakePolicyCommandTest.php
+++ b/tests/Commands/MakePolicyCommandTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NorbyBaru\Modularize\Tests\Commands;
+
+use NorbyBaru\Modularize\Tests\MakeCommandTestCase;
+
+class MakePolicyCommandTest extends MakeCommandTestCase
+{
+    public function test_it_should_create_a_policy()
+    {
+        $this->artisan(
+            command: 'module:make:policy',
+            parameters: [
+                'name' => 'PostPolicy',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Policies/PostPolicy.php');
+    }
+
+    public function test_it_should_fail_to_create_policy_on_duplicate_filename()
+    {
+        $this->artisan(
+            command: 'module:make:policy',
+            parameters: [
+                'name' => 'PostPolicy',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Policies/PostPolicy.php');
+
+        $this->artisan(
+            command: 'module:make:policy',
+            parameters: [
+                'name' => 'PostPolicy',
+                '--module' => $this->moduleName,
+            ]
+        )->assertFailed();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Policies/PostPolicy.php');
+    }
+}

--- a/tests/Commands/MakeProviderCommandTest.php
+++ b/tests/Commands/MakeProviderCommandTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NorbyBaru\Modularize\Tests\Commands;
+
+use NorbyBaru\Modularize\Tests\MakeCommandTestCase;
+
+class MakeProviderCommandTest extends MakeCommandTestCase
+{
+    public function test_it_should_create_a_provider()
+    {
+        $this->artisan(
+            command: 'module:make:provider',
+            parameters: [
+                'name' => 'AppServiceProvider',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Providers/AppServiceProvider.php');
+    }
+
+    public function test_it_should_fail_to_create_provider_on_duplicate_filename()
+    {
+        $this->artisan(
+            command: 'module:make:provider',
+            parameters: [
+                'name' => 'AppServiceProvider',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Providers/AppServiceProvider.php');
+
+        $this->artisan(
+            command: 'module:make:provider',
+            parameters: [
+                'name' => 'AppServiceProvider',
+                '--module' => $this->moduleName,
+            ]
+        )->assertFailed();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Providers/AppServiceProvider.php');
+    }
+}

--- a/tests/Commands/MakeRequestCommandTest.php
+++ b/tests/Commands/MakeRequestCommandTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NorbyBaru\Modularize\Tests\Commands;
+
+use NorbyBaru\Modularize\Tests\MakeCommandTestCase;
+
+class MakeRequestCommandTest extends MakeCommandTestCase
+{
+    public function test_it_should_create_a_request()
+    {
+        $this->artisan(
+            command: 'module:make:request',
+            parameters: [
+                'name' => 'StorePostRequest',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Requests/StorePostRequest.php');
+    }
+
+    public function test_it_should_fail_to_create_request_on_duplicate_filename()
+    {
+        $this->artisan(
+            command: 'module:make:request',
+            parameters: [
+                'name' => 'StorePostRequest',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Requests/StorePostRequest.php');
+
+        $this->artisan(
+            command: 'module:make:request',
+            parameters: [
+                'name' => 'StorePostRequest',
+                '--module' => $this->moduleName,
+            ]
+        )->assertFailed();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Requests/StorePostRequest.php');
+    }
+}

--- a/tests/Commands/MakeResourceCommandTest.php
+++ b/tests/Commands/MakeResourceCommandTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace NorbyBaru\Modularize\Tests\Commands;
+
+use NorbyBaru\Modularize\Tests\MakeCommandTestCase;
+
+class MakeResourceCommandTest extends MakeCommandTestCase
+{
+    public function test_it_should_create_a_resource()
+    {
+        $this->artisan(
+            command: 'module:make:resource',
+            parameters: [
+                'name' => 'UserResource',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Resources/UserResource.php');
+    }
+
+    public function test_it_should_create_a_resource_collection()
+    {
+        $this->artisan(
+            command: 'module:make:resource',
+            parameters: [
+                'name' => 'UserResource',
+                '--module' => $this->moduleName,
+                '--collection' => true,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Resources/UserResource.php');
+    }
+
+    public function test_it_should_fail_to_create_resource_on_duplicate_filename()
+    {
+        $this->artisan(
+            command: 'module:make:resource',
+            parameters: [
+                'name' => 'UserResource',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Resources/UserResource.php');
+
+        $this->artisan(
+            command: 'module:make:resource',
+            parameters: [
+                'name' => 'UserResource',
+                '--module' => $this->moduleName,
+            ]
+        )->assertFailed();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Resources/UserResource.php');
+    }
+}

--- a/tests/Commands/MakeTestCommandTest.php
+++ b/tests/Commands/MakeTestCommandTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace NorbyBaru\Modularize\Tests\Commands;
+
+use NorbyBaru\Modularize\Tests\MakeCommandTestCase;
+
+class MakeTestCommandTest extends MakeCommandTestCase
+{
+    public function test_it_creates_a_feature_test()
+    {
+        $this->artisan(
+            command: 'module:make:test',
+            parameters: [
+                'name' => 'ExampleTest',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Tests/Feature/ExampleTest.php');
+    }
+
+    public function test_it_creates_a_unit_test()
+    {
+        $this->artisan(
+            command: 'module:make:test',
+            parameters: [
+                'name' => 'ExampleTest',
+                '--module' => $this->moduleName,
+                '--unit' => true,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Tests/Unit/ExampleTest.php');
+    }
+
+    public function test_it_creates_a_pest_feature_test()
+    {
+        $this->artisan(
+            command: 'module:make:test',
+            parameters: [
+                'name' => 'PestExampleTest',
+                '--module' => $this->moduleName,
+                '--pest' => true,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Tests/Feature/PestExampleTest.php');
+    }
+
+    public function test_it_creates_a_view_test()
+    {
+        $this->artisan(
+            command: 'module:make:test',
+            parameters: [
+                'name' => 'home',
+                '--module' => $this->moduleName,
+                '--view' => true,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Tests/Feature/View/HomeTest.php');
+    }
+}

--- a/tests/Commands/MakeViewCommandTest.php
+++ b/tests/Commands/MakeViewCommandTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NorbyBaru\Modularize\Tests\Commands;
+
+use NorbyBaru\Modularize\Tests\MakeCommandTestCase;
+
+class MakeViewCommandTest extends MakeCommandTestCase
+{
+    public function test_it_should_create_a_view()
+    {
+        $this->artisan(
+            command: 'module:make:view',
+            parameters: [
+                'name' => 'index',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Views/index.blade.php');
+    }
+
+    public function test_it_should_fail_to_create_view_on_duplicate_filename()
+    {
+        $this->artisan(
+            command: 'module:make:view',
+            parameters: [
+                'name' => 'index',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Views/index.blade.php');
+
+        $this->artisan(
+            command: 'module:make:view',
+            parameters: [
+                'name' => 'index',
+                '--module' => $this->moduleName,
+            ]
+        )->assertFailed();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Views/index.blade.php');
+    }
+}

--- a/tests/MakeCommandTestCase.php
+++ b/tests/MakeCommandTestCase.php
@@ -4,6 +4,7 @@ namespace NorbyBaru\Modularize\Tests;
 
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Carbon;
+use Symfony\Component\Finder\SplFileInfo;
 
 abstract class MakeCommandTestCase extends TestCase
 {
@@ -50,7 +51,7 @@ abstract class MakeCommandTestCase extends TestCase
             actual: count($migrations)
         );
 
-        /** @var \Symfony\Component\Finder\SplFileInfo */
+        /** @var SplFileInfo */
         $migrationFile = $migrations[0];
         $this->assertStringContainsString(
             needle: $migrationFilename,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@ use Orchestra\Testbench\TestCase as OrchestraTestCase;
 
 abstract class TestCase extends OrchestraTestCase
 {
+    public static $latestResponse;
     public function getModulePath(string $module): string
     {
         return base_path(config('modularize.root_path')."/$module");

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,6 +8,7 @@ use Orchestra\Testbench\TestCase as OrchestraTestCase;
 abstract class TestCase extends OrchestraTestCase
 {
     public static $latestResponse;
+
     public function getModulePath(string $module): string
     {
         return base_path(config('modularize.root_path')."/$module");


### PR DESCRIPTION
Only 5 of 17 ModuleMake*Command classes have tests (Console, Controller, Factory, Migration, Model). The remaining 12 commands (Component, Event, Job, Listener, Middleware, Notification, Policy, Provider, Request, Resource, Test, View) have no test coverage. The MakeCommandTestCase base class provides a ready-made pattern for writing these.