### PR TITLE
Add module:make:mail command

### DIFF
--- a/src/Console/Commands/ModuleMakeMailCommand.php
+++ b/src/Console/Commands/ModuleMakeMailCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace NorbyBaru\Modularize\Console\Commands;
+
+use Illuminate\Support\Str;
+
+class ModuleMakeMailCommand extends ModuleMakerCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'module:make:mail
+                            {name : The name of the mail}
+                            {--module= : Name of module mail should belong to}
+                            {--markdown= : Create a new Markdown template for the mailable}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate mail class for module';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Mail';
+
+    public function handle(): ?bool
+    {
+        $module = $this->getModuleInput();
+        $filename = Str::studly($this->getNameInput());
+        $folder = $this->getFolderPath();
+
+        $name = $this->qualifyClass($module.'\\'.$folder.'\\'.$filename);
+
+        if ($this->files->exists($path = $this->getPath($name))) {
+            $this->logFileExist($name);
+
+            return true;
+        }
+
+        $this->setStubFile('mail.');
+        $this->makeDirectory($path);
+
+        $this->files->put($path, $this->buildClass($name));
+
+        $this->logFileCreated($name);
+
+        return null;
+    }
+
+    protected function getFolderPath(): string
+    {
+        return 'Mail';
+    }
+}

--- a/src/Console/Commands/templates/mail.sample
+++ b/src/Console/Commands/templates/mail.sample
@@ -1,0 +1,53 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class {{ class }} extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: '{{ class }}',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            view: 'view.name',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/src/ModularizeServiceProvider.php
+++ b/src/ModularizeServiceProvider.php
@@ -16,6 +16,7 @@ use NorbyBaru\Modularize\Console\Commands\ModuleMakeEventCommand;
 use NorbyBaru\Modularize\Console\Commands\ModuleMakeFactoryCommand;
 use NorbyBaru\Modularize\Console\Commands\ModuleMakeJobCommand;
 use NorbyBaru\Modularize\Console\Commands\ModuleMakeListenerCommand;
+use NorbyBaru\Modularize\Console\Commands\ModuleMakeMailCommand;
 use NorbyBaru\Modularize\Console\Commands\ModuleMakeMiddlewareCommand;
 use NorbyBaru\Modularize\Console\Commands\ModuleMakeMigrationCommand;
 use NorbyBaru\Modularize\Console\Commands\ModuleMakeModelCommand;
@@ -293,6 +294,7 @@ class ModularizeServiceProvider extends ServiceProvider
             ModuleMakeFactoryCommand::class,
             ModuleMakeJobCommand::class,
             ModuleMakeListenerCommand::class,
+            ModuleMakeMailCommand::class,
             ModuleMakeModelCommand::class,
             ModuleMakeMiddlewareCommand::class,
             ModuleMakeMigrationCommand::class,

--- a/tests/Commands/MakeMailCommandTest.php
+++ b/tests/Commands/MakeMailCommandTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NorbyBaru\Modularize\Tests\Commands;
+
+use NorbyBaru\Modularize\Tests\MakeCommandTestCase;
+
+class MakeMailCommandTest extends MakeCommandTestCase
+{
+    public function test_it_should_create_a_mail()
+    {
+        $this->artisan(
+            command: 'module:make:mail',
+            parameters: [
+                'name' => 'UserRegistered',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Mail/UserRegistered.php');
+    }
+
+    public function test_it_should_fail_to_create_mail_on_duplicate_filename()
+    {
+        $this->artisan(
+            command: 'module:make:mail',
+            parameters: [
+                'name' => 'UserRegistered',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Mail/UserRegistered.php');
+
+        $this->artisan(
+            command: 'module:make:mail',
+            parameters: [
+                'name' => 'UserRegistered',
+                '--module' => $this->moduleName,
+            ]
+        )->assertFailed();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Mail/UserRegistered.php');
+    }
+}


### PR DESCRIPTION
Add a ModuleMakeMailCommand to generate Mailable classes within modules. Laravel's make:mail is a standard artisan generator, and the package's command pattern supports adding this with minimal effort. The existing notification command and view command patterns provide the exact blueprint.