### PR TITLE
Standardize command description phrasing

### DIFF
--- a/src/Console/Commands/ModuleMakeEventCommand.php
+++ b/src/Console/Commands/ModuleMakeEventCommand.php
@@ -20,7 +20,7 @@ class ModuleMakeEventCommand extends ModuleMakerCommand
      *
      * @var string
      */
-    protected $description = 'Generate event for module';
+    protected $description = 'Generate event for a module';
 
     /**
      * The type of class being generated.

--- a/src/Console/Commands/ModuleMakeFactoryCommand.php
+++ b/src/Console/Commands/ModuleMakeFactoryCommand.php
@@ -19,7 +19,7 @@ class ModuleMakeFactoryCommand extends ModuleMakerCommand
      *
      * @var string
      */
-    protected $description = 'Generate model factory for module';
+    protected $description = 'Generate factory for a module';
 
     /**
      * The type of class being generated.

--- a/src/Console/Commands/ModuleMakeJobCommand.php
+++ b/src/Console/Commands/ModuleMakeJobCommand.php
@@ -21,7 +21,7 @@ class ModuleMakeJobCommand extends ModuleMakerCommand
      *
      * @var string
      */
-    protected $description = 'Generate job for module';
+    protected $description = 'Generate job for a module';
 
     /**
      * The type of class being generated.

--- a/src/Console/Commands/ModuleMakeListenerCommand.php
+++ b/src/Console/Commands/ModuleMakeListenerCommand.php
@@ -22,7 +22,7 @@ class ModuleMakeListenerCommand extends ModuleMakerCommand
      *
      * @var string
      */
-    protected $description = 'Generate listener for module';
+    protected $description = 'Generate listener for a module';
 
     /**
      * The type of class being generated.

--- a/src/Console/Commands/ModuleMakeMailCommand.php
+++ b/src/Console/Commands/ModuleMakeMailCommand.php
@@ -21,7 +21,7 @@ class ModuleMakeMailCommand extends ModuleMakerCommand
      *
      * @var string
      */
-    protected $description = 'Generate mail class for module';
+    protected $description = 'Generate mail for a module';
 
     /**
      * The type of class being generated.

--- a/src/Console/Commands/ModuleMakeMiddlewareCommand.php
+++ b/src/Console/Commands/ModuleMakeMiddlewareCommand.php
@@ -20,7 +20,7 @@ class ModuleMakeMiddlewareCommand extends ModuleMakerCommand
      *
      * @var string
      */
-    protected $description = 'Generate middleware for module';
+    protected $description = 'Generate middleware for a module';
 
     /**
      * The type of class being generated.

--- a/src/Console/Commands/ModuleMakeNotificationCommand.php
+++ b/src/Console/Commands/ModuleMakeNotificationCommand.php
@@ -22,7 +22,7 @@ class ModuleMakeNotificationCommand extends ModuleMakerCommand
      *
      * @var string
      */
-    protected $description = 'Generate notification for module';
+    protected $description = 'Generate notification for a module';
 
     /**
      * The type of class being generated.

--- a/src/Console/Commands/ModuleMakePolicyCommand.php
+++ b/src/Console/Commands/ModuleMakePolicyCommand.php
@@ -22,7 +22,7 @@ class ModuleMakePolicyCommand extends ModuleMakerCommand
      *
      * @var string
      */
-    protected $description = 'Generate policy for module';
+    protected $description = 'Generate policy for a module';
 
     /**
      * The type of class being generated.

--- a/src/Console/Commands/ModuleMakeProviderCommand.php
+++ b/src/Console/Commands/ModuleMakeProviderCommand.php
@@ -20,7 +20,7 @@ class ModuleMakeProviderCommand extends ModuleMakerCommand
      *
      * @var string
      */
-    protected $description = 'Generate provider for module';
+    protected $description = 'Generate provider for a module';
 
     /**
      * The type of class being generated.

--- a/src/Console/Commands/ModuleMakeSeederCommand.php
+++ b/src/Console/Commands/ModuleMakeSeederCommand.php
@@ -19,7 +19,7 @@ class ModuleMakeSeederCommand extends ModuleMakerCommand
      *
      * @var string
      */
-    protected $description = 'Generate seeder for module';
+    protected $description = 'Generate seeder for a module';
 
     /**
      * The type of class being generated.

--- a/src/Console/Commands/ModuleMakeTestCommand.php
+++ b/src/Console/Commands/ModuleMakeTestCommand.php
@@ -24,7 +24,7 @@ class ModuleMakeTestCommand extends ModuleMakerCommand
      *
      * @var string
      */
-    protected $description = 'Generate test resource for a module';
+    protected $description = 'Generate test for a module';
 
     /**
      * The type of class being generated.

--- a/src/Console/Commands/ModuleMakeViewCommand.php
+++ b/src/Console/Commands/ModuleMakeViewCommand.php
@@ -20,7 +20,7 @@ class ModuleMakeViewCommand extends ModuleMakerCommand
      *
      * @var string
      */
-    protected $description = 'Generate view resource for a module';
+    protected $description = 'Generate view for a module';
 
     /**
      * The type of class being generated.


### PR DESCRIPTION
Standardize the $description property across all 17 commands to use a consistent grammatical pattern. Currently descriptions mix formats: 'Generate model for a module', 'Generate controller for a module', 'Generate listener for module' (missing article), 'Generate view resource for a module' (extra word 'resource').