### PR TITLE
Improve error message for file existence conflicts

### DIFF
--- a/src/Console/Commands/ModuleMakeControllerCommand.php
+++ b/src/Console/Commands/ModuleMakeControllerCommand.php
@@ -60,8 +60,7 @@ class ModuleMakeControllerCommand extends ModuleMakerCommand
             return true;
         }
 
-        $this->setStubFile("controller.{$type}");
-        $this->generateFile($path, $name);
+        $this->generateFile($path, $name, $type);
 
         return null;
     }
@@ -69,10 +68,5 @@ class ModuleMakeControllerCommand extends ModuleMakerCommand
     protected function getFolderPath(): string
     {
         return 'Controllers';
-    }
-
-    protected function setStubFile(string $file): void
-    {
-        $this->currentStub = $this->currentStub.$file.'sample';
     }
 }

--- a/src/Console/Commands/ModuleMakeControllerCommand.php
+++ b/src/Console/Commands/ModuleMakeControllerCommand.php
@@ -3,7 +3,6 @@
 namespace NorbyBaru\Modularize\Console\Commands;
 
 use Illuminate\Support\Str;
-use Symfony\Component\Console\Input\InputArgument;
 
 class ModuleMakeControllerCommand extends ModuleMakerCommand
 {
@@ -18,7 +17,8 @@ class ModuleMakeControllerCommand extends ModuleMakerCommand
                             {--api : Exclude the create and edit methods from the controller}
                             {--i|invokable : Generate a single method, invokable controller class}
                             {--r|resource : Generate a resource controller class}
-                            {--m|model= : Generate a resource controller for the given model}';
+                            {--m|model= : Generate a resource controller for the given model}
+                            {--force : Create the class even if the component already exists}';
 
     /**
      * The console command description.
@@ -56,17 +56,12 @@ class ModuleMakeControllerCommand extends ModuleMakerCommand
 
         $name = $this->qualifyClass($module.'\\'.$folder.'\\'.$filename);
 
-        if ($this->files->exists($path = $this->getPath($name))) {
-            $this->logFileExist($name);
-
+        if (! $path = $this->getFilePath(name: $name, force: $this->option('force'))) {
             return true;
         }
 
         $this->setStubFile("controller.{$type}");
-        $this->makeDirectory($path);
-        $this->files->put($path, $this->buildClass($name));
-
-        $this->logFileCreated($name);
+        $this->generateFile($path, $name);
 
         return null;
     }
@@ -79,17 +74,5 @@ class ModuleMakeControllerCommand extends ModuleMakerCommand
     protected function setStubFile(string $file): void
     {
         $this->currentStub = $this->currentStub.$file.'sample';
-    }
-
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
-    protected function getArguments()
-    {
-        return [
-            ['name', InputArgument::REQUIRED, 'The name of the controller'],
-        ];
     }
 }

--- a/src/Console/Commands/ModuleMakeEventCommand.php
+++ b/src/Console/Commands/ModuleMakeEventCommand.php
@@ -13,7 +13,8 @@ class ModuleMakeEventCommand extends ModuleMakerCommand
      */
     protected $signature = 'module:make:event
                             {name : The name of the event}
-                            {--module= : Name of module event should belong to}';
+                            {--module= : Name of module event should belong to}
+                            {--force : Create the class even if the component already exists}';
 
     /**
      * The console command description.
@@ -37,7 +38,7 @@ class ModuleMakeEventCommand extends ModuleMakerCommand
 
         $name = $this->qualifyClass($module.'\\'.$folder.'\\'.$filename);
 
-        if (! $path = $this->getFilePath($name)) {
+        if (! $path = $this->getFilePath(name: $name, force: $this->option('force'))) {
             return true;
         }
 

--- a/src/Console/Commands/ModuleMakeJobCommand.php
+++ b/src/Console/Commands/ModuleMakeJobCommand.php
@@ -14,7 +14,8 @@ class ModuleMakeJobCommand extends ModuleMakerCommand
     protected $signature = 'module:make:job
                             {name : The name of the job}
                             {--module= : Name of module job should belong to}
-                            {--sync : Indicates that job should be synchronous}';
+                            {--sync : Indicates that job should be synchronous}
+                            {--force : Create the class even if the component already exists}';
 
     /**
      * The console command description.
@@ -38,7 +39,7 @@ class ModuleMakeJobCommand extends ModuleMakerCommand
 
         $name = $this->qualifyClass($module.'\\'.$folder.'\\'.$filename);
 
-        if (! $path = $this->getFilePath($name)) {
+        if (! $path = $this->getFilePath(name: $name, force: $this->option('force'))) {
             return true;
         }
 

--- a/src/Console/Commands/ModuleMakeListenerCommand.php
+++ b/src/Console/Commands/ModuleMakeListenerCommand.php
@@ -15,7 +15,8 @@ class ModuleMakeListenerCommand extends ModuleMakerCommand
                             {name : The name of the listener}
                             {--module= : Name of module event should belong to}
                             {--event= : The event class being listened for}
-                            {--queued : Indicates the event listener should be queued }';
+                            {--queued : Indicates the event listener should be queued }
+                            {--force : Create the class even if the component already exists}';
 
     /**
      * The console command description.
@@ -39,7 +40,7 @@ class ModuleMakeListenerCommand extends ModuleMakerCommand
 
         $name = $this->qualifyClass($module.'\\'.$folder.'\\'.$filename);
 
-        if (! $path = $this->getFilePath($name)) {
+        if (! $path = $this->getFilePath(name: $name, force: $this->option('force'))) {
             return true;
         }
 

--- a/src/Console/Commands/ModuleMakeModelCommand.php
+++ b/src/Console/Commands/ModuleMakeModelCommand.php
@@ -18,6 +18,7 @@ class ModuleMakeModelCommand extends ModuleMakerCommand
                         {--a|all : Generate a migration, seeder, factory, policy, resource controller, and form request classes for the model}
                         {--c|controller : Create a new controller for the model}
                         {--f|factory : Create a new factory for the model}
+                        {--force : Create the class even if the component already exists}
                         {--m|migration : Create a new migration file for the model}
                         {--p|pivot : Indicates if the generated model should be a custom intermediate table model}
                         {--policy :  Create a new policy for the model}
@@ -54,9 +55,7 @@ class ModuleMakeModelCommand extends ModuleMakerCommand
 
         $name = $this->qualifyClass($module.'\\'.$folder.'\\'.$filename);
 
-        if ($this->files->exists($path = $this->getPath($name))) {
-            $this->logFileExist($name);
-
+        if (! $path = $this->getFilePath(name: $name, force: $this->option('force'))) {
             return true;
         }
 

--- a/src/Console/Commands/ModuleMakeTestCommand.php
+++ b/src/Console/Commands/ModuleMakeTestCommand.php
@@ -17,7 +17,8 @@ class ModuleMakeTestCommand extends ModuleMakerCommand
                             {--module= : Name of module migration should belong to}
                             {--u|unit : Create a unit test}
                             {--p|pest : Create a Pest test}
-                            {--view : Create a view test}';
+                            {--view : Create a view test}
+                            {--force : Create the class even if the component already exists}';
 
     /**
      * The console command description.
@@ -64,9 +65,7 @@ class ModuleMakeTestCommand extends ModuleMakerCommand
 
         $name = $this->qualifyClass($module.'\\'.$folder.'\\'.$testType.'\\'.$filename);
 
-        if ($this->files->exists($path = $this->getPath($name))) {
-            $this->logFileExist($name);
-
+        if (! $path = $this->getFilePath(name: $name, force: $this->option('force'))) {
             return true;
         }
 

--- a/src/Console/Commands/ModuleMakeViewCommand.php
+++ b/src/Console/Commands/ModuleMakeViewCommand.php
@@ -13,7 +13,8 @@ class ModuleMakeViewCommand extends ModuleMakerCommand
                             {name : The name of the view}
                             {--module= : Name of module migration should belong to}
                             {--test : Generate an accompanying PHPUnit test for the View}
-                            {--pest : Generate an accompanying Pest test for the View}';
+                            {--pest : Generate an accompanying Pest test for the View}
+                            {--force : Create the class even if the component already exists}';
 
     /**
      * The console command description.
@@ -37,8 +38,8 @@ class ModuleMakeViewCommand extends ModuleMakerCommand
 
         $name = $this->qualifyClass($module.'\\'.$folder.'\\'.$filename);
 
-        if ($this->files->exists($path = $this->getPath($name, 'blade.php'))) {
-            $this->logFileExist($name);
+        if ($this->files->exists($path = $this->getPath($name, 'blade.php')) && ! $this->option('force')) {
+            $this->logFileExist($path);
 
             return true;
         }

--- a/src/Console/Commands/ModuleMakerCommand.php
+++ b/src/Console/Commands/ModuleMakerCommand.php
@@ -312,7 +312,7 @@ abstract class ModuleMakerCommand extends GeneratorCommand
     protected function getFilePath(string $name, bool $force = false): ?string
     {
         if ($this->files->exists($path = $this->getPath($name)) && ! $force) {
-            $this->logFileExist($name);
+            $this->logFileExist($path);
 
             return null;
         }
@@ -348,7 +348,8 @@ abstract class ModuleMakerCommand extends GeneratorCommand
     protected function logFileExist(string $path)
     {
         if (! $this->hasOption('quiet') || ! $this->option('quiet')) {
-            $this->components->error(sprintf('%s [%s] already exist.', $this->type, $path));
+            $this->components->error(sprintf('%s [%s] already exists.', $this->type, $path));
+            $this->components->info('Use the --force option to overwrite the existing file.');
         }
     }
 

--- a/tests/Commands/MakeModelCommandTest.php
+++ b/tests/Commands/MakeModelCommandTest.php
@@ -124,4 +124,55 @@ class MakeModelCommandTest extends MakeCommandTestCase
         $this->assertFactoryFile(module: $this->moduleName, filename: 'ArticleFactory');
         $this->assertSeederFile(module: $this->moduleName, filename: 'ArticleSeeder');
     }
+
+    public function test_it_should_fail_to_create_model_on_duplicate_filename()
+    {
+        $this->artisan(
+            command: 'module:make:model',
+            parameters: [
+                'name' => 'Post',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Models/Post.php');
+
+        $this->artisan(
+            command: 'module:make:model',
+            parameters: [
+                'name' => 'Post',
+                '--module' => $this->moduleName,
+            ]
+        )->assertFailed();
+
+        $this->assertFileExists(filename: $this->getModulePath().'/Models/Post.php');
+    }
+
+    public function test_it_displays_improved_error_message_when_file_already_exists()
+    {
+        // Create the model first time - should succeed
+        $this->artisan(
+            command: 'module:make:model',
+            parameters: [
+                'name' => 'User',
+                '--module' => $this->moduleName,
+            ]
+        )->assertSuccessful();
+
+        $filePath = $this->getModulePath().'/Models/User.php';
+        $this->assertFileExists(filename: $filePath);
+
+        // Try to create the same model again - should fail with improved error message
+        // The error message format is: "Model [<full-path>] already exists." (see ModuleMakerCommand::logFileExist)
+        $this->artisan(
+            command: 'module:make:model',
+            parameters: [
+                'name' => 'User',
+                '--module' => $this->moduleName,
+            ]
+        )
+            ->expectsOutputToContain('already exists')  // Verify correct grammar (not "already exist")
+            ->expectsOutputToContain('--force')         // Verify --force suggestion is shown
+            ->assertFailed();
+    }
 }


### PR DESCRIPTION
Enhance the logFileExist() error message to include the full file path and suggest using a --force flag to overwrite, matching Laravel's native command behavior.