### PR TITLE
Fix inconsistent file-existence checking across command classes

### DIFF
--- a/src/Console/Commands/ModuleMakeFactoryCommand.php
+++ b/src/Console/Commands/ModuleMakeFactoryCommand.php
@@ -12,7 +12,8 @@ class ModuleMakeFactoryCommand extends ModuleMakerCommand
     protected $signature = 'module:make:factory
                 {name : The name of the factory}
                 {--module= : Name of module policy should belong to}
-                {--model= : The name of the model for the factory}';
+                {--model= : The name of the model for the factory}
+                {--force : Create the class even if the component already exists}';
 
     /**
      * The console command description.
@@ -43,9 +44,7 @@ class ModuleMakeFactoryCommand extends ModuleMakerCommand
 
         $name = $this->qualifyClass($module.'\\'.$folder.'\\'.$filename);
 
-        if ($this->files->exists($path = $this->getPath($name))) {
-            $this->logFileExist($name);
-
+        if (! $path = $this->getFilePath(name: $name, force: $this->option('force'))) {
             return true;
         }
 

--- a/src/Console/Commands/ModuleMakeMailCommand.php
+++ b/src/Console/Commands/ModuleMakeMailCommand.php
@@ -14,7 +14,8 @@ class ModuleMakeMailCommand extends ModuleMakerCommand
     protected $signature = 'module:make:mail
                             {name : The name of the mail}
                             {--module= : Name of module mail should belong to}
-                            {--markdown= : Create a new Markdown template for the mailable}';
+                            {--markdown= : Create a new Markdown template for the mailable}
+                            {--force : Create the class even if the component already exists}';
 
     /**
      * The console command description.
@@ -38,18 +39,13 @@ class ModuleMakeMailCommand extends ModuleMakerCommand
 
         $name = $this->qualifyClass($module.'\\'.$folder.'\\'.$filename);
 
-        if ($this->files->exists($path = $this->getPath($name))) {
-            $this->logFileExist($name);
-
+        if (! $path = $this->getFilePath(name: $name, force: $this->option('force'))) {
             return true;
         }
 
-        $this->setStubFile('mail.');
-        $this->makeDirectory($path);
+        $type = '';
 
-        $this->files->put($path, $this->buildClass($name));
-
-        $this->logFileCreated($name);
+        $this->generateFile($path, $name, $type);
 
         return null;
     }

--- a/src/Console/Commands/ModuleMakeMiddlewareCommand.php
+++ b/src/Console/Commands/ModuleMakeMiddlewareCommand.php
@@ -13,7 +13,8 @@ class ModuleMakeMiddlewareCommand extends ModuleMakerCommand
      */
     protected $signature = 'module:make:middleware
                             {name : The name of the middleware}
-                            {--module= : Name of module middleware should belong to}';
+                            {--module= : Name of module middleware should belong to}
+                            {--force : Create the class even if the component already exists}';
 
     /**
      * The console command description.
@@ -37,21 +38,13 @@ class ModuleMakeMiddlewareCommand extends ModuleMakerCommand
 
         $name = $this->qualifyClass($module.'\\'.$folder.'\\'.$filename);
 
-        if ($this->files->exists($path = $this->getPath($name))) {
-            $this->logFileExist($name);
-
+        if (! $path = $this->getFilePath(name: $name, force: $this->option('force'))) {
             return true;
         }
 
         $type = '';
-        $this->setStubFile("middleware.{$type}");
-        $this->makeDirectory($path);
 
-        $stub = $this->buildClass($name);
-
-        $this->files->put($path, $stub);
-
-        $this->logFileCreated($name);
+        $this->generateFile($path, $name, $type);
 
         return null;
     }

--- a/src/Console/Commands/ModuleMakeNotificationCommand.php
+++ b/src/Console/Commands/ModuleMakeNotificationCommand.php
@@ -15,7 +15,8 @@ class ModuleMakeNotificationCommand extends ModuleMakerCommand
                             {name : The name of the notification}
                             {--module= : Name of module migration should belong to}
                             {--model= : The model that the policy applies to}
-                            {--guard= : The guard that the policy relies on}';
+                            {--guard= : The guard that the policy relies on}
+                            {--force : Create the class even if the component already exists}';
 
     /**
      * The console command description.
@@ -39,18 +40,11 @@ class ModuleMakeNotificationCommand extends ModuleMakerCommand
 
         $name = $this->qualifyClass($module.'\\'.$folder.'\\'.$filename);
 
-        if ($this->files->exists($path = $this->getPath($name))) {
-            $this->logFileExist($name);
-
+        if (! $path = $this->getFilePath(name: $name, force: $this->option('force'))) {
             return true;
         }
 
-        $this->setStubFile('notification.');
-        $this->makeDirectory($path);
-
-        $this->files->put($path, $this->buildClass($name));
-
-        $this->logFileCreated($name);
+        $this->generateFile($path, $name, '');
 
         return null;
     }

--- a/src/Console/Commands/ModuleMakePolicyCommand.php
+++ b/src/Console/Commands/ModuleMakePolicyCommand.php
@@ -15,7 +15,8 @@ class ModuleMakePolicyCommand extends ModuleMakerCommand
                             {name : The name of the policy}
                             {--module= : Name of module policy should belong to}
                             {--model= : The model that the policy applies to}
-                            {--guard= : The guard that the policy relies on}';
+                            {--guard= : The guard that the policy relies on}
+                            {--force : Create the class even if the component already exists}';
 
     /**
      * The console command description.
@@ -37,36 +38,31 @@ class ModuleMakePolicyCommand extends ModuleMakerCommand
         $filename = Str::studly($this->getNameInput());
         $folder = $this->getFolderPath();
 
+        $name = $this->qualifyClass($module.'\\'.$folder.'\\'.$filename);
+
+        if (! $path = $this->getFilePath(name: $name, force: $this->option('force'))) {
+            return true;
+        }
+
         $type = '';
+        $model = null;
 
         if ($model = $this->option('model')) {
             $type = 'model.';
             $model = $this->qualifyClass($module.'\\'.'Models'.'\\'.$model);
         }
 
-        $name = $this->qualifyClass($module.'\\'.$folder.'\\'.$filename);
-
-        if ($this->files->exists($path = $this->getPath($name))) {
-            $this->logFileExist($name);
-
-            return true;
-        }
-
-        $this->setStubFile("policy.{$type}");
-        $this->makeDirectory($path);
-
-        $stub = $this->buildClass($name);
-
         if ($model) {
+            $this->setStubFile("policy.{$type}");
+            $this->makeDirectory($path);
+            $stub = $this->buildClass($name);
             $this->files->put($path, $this->buildModel($stub, $model));
             $this->logFileCreated($name);
 
             return null;
         }
 
-        $this->files->put($path, $stub);
-
-        $this->logFileCreated($name);
+        $this->generateFile($path, $name, $type);
 
         return null;
     }

--- a/src/Console/Commands/ModuleMakePolicyCommand.php
+++ b/src/Console/Commands/ModuleMakePolicyCommand.php
@@ -53,11 +53,7 @@ class ModuleMakePolicyCommand extends ModuleMakerCommand
         }
 
         if ($model) {
-            $this->setStubFile("policy.{$type}");
-            $this->makeDirectory($path);
-            $stub = $this->buildClass($name);
-            $this->files->put($path, $this->buildModel($stub, $model));
-            $this->logFileCreated($name);
+            $this->generateFileWithModel($path, $name, $type, $model);
 
             return null;
         }
@@ -65,6 +61,15 @@ class ModuleMakePolicyCommand extends ModuleMakerCommand
         $this->generateFile($path, $name, $type);
 
         return null;
+    }
+
+    protected function generateFileWithModel(string $path, string $name, string $type, string $model): void
+    {
+        $this->setStubFile("policy.{$type}");
+        $this->makeDirectory($path);
+        $stub = $this->buildClass($name);
+        $this->files->put($path, $this->buildModel($stub, $model));
+        $this->logFileCreated($name);
     }
 
     protected function getFolderPath(): string

--- a/src/Console/Commands/ModuleMakeProviderCommand.php
+++ b/src/Console/Commands/ModuleMakeProviderCommand.php
@@ -11,9 +11,10 @@ class ModuleMakeProviderCommand extends ModuleMakerCommand
      *
      * @var string
      */
-    protected $signature = 'module:make:provider 
+    protected $signature = 'module:make:provider
                             {name : The name of the provider}
-                            {--module= : Name of module migration should belong to}';
+                            {--module= : Name of module migration should belong to}
+                            {--force : Create the class even if the component already exists}';
 
     /**
      * The console command description.
@@ -27,9 +28,9 @@ class ModuleMakeProviderCommand extends ModuleMakerCommand
      *
      * @var string
      */
-    protected $type = 'Providers';
+    protected $type = 'Provider';
 
-    public function handle()
+    public function handle(): ?bool
     {
         $module = $this->getModuleInput();
         $filename = Str::studly($this->getNameInput());
@@ -37,18 +38,11 @@ class ModuleMakeProviderCommand extends ModuleMakerCommand
 
         $name = $this->qualifyClass($module.'\\'.$folder.'\\'.$filename);
 
-        if ($this->files->exists($path = $this->getPath($name))) {
-            $this->logFileExist($name);
-
+        if (! $path = $this->getFilePath(name: $name, force: $this->option('force'))) {
             return true;
         }
 
-        $this->setStubFile('provider.');
-        $this->makeDirectory($path);
-
-        $this->files->put($path, $this->buildClass($name));
-
-        $this->logFileCreated($name);
+        $this->generateFile($path, $name, '');
 
         return null;
     }

--- a/src/Console/Commands/ModuleMakeRequestCommand.php
+++ b/src/Console/Commands/ModuleMakeRequestCommand.php
@@ -13,7 +13,8 @@ class ModuleMakeRequestCommand extends ModuleMakerCommand
      */
     protected $signature = 'module:make:request
                             {name : The name of the request}
-                            {--module= : Name of module migration should belong to}';
+                            {--module= : Name of module migration should belong to}
+                            {--force : Create the class even if the component already exists}';
 
     /**
      * The console command description.
@@ -37,18 +38,11 @@ class ModuleMakeRequestCommand extends ModuleMakerCommand
 
         $name = $this->qualifyClass($module.'\\'.$folder.'\\'.$filename);
 
-        if ($this->files->exists($path = $this->getPath($name))) {
-            $this->logFileExist($name);
-
+        if (! $path = $this->getFilePath(name: $name, force: $this->option('force'))) {
             return true;
         }
 
-        $this->setStubFile('request.');
-        $this->makeDirectory($path);
-
-        $this->files->put($path, $this->buildClass($name));
-
-        $this->logFileCreated($name);
+        $this->generateFile($path, $name, '');
 
         return null;
     }

--- a/src/Console/Commands/ModuleMakeResourceCommand.php
+++ b/src/Console/Commands/ModuleMakeResourceCommand.php
@@ -14,7 +14,8 @@ class ModuleMakeResourceCommand extends ModuleMakerCommand
     protected $signature = 'module:make:resource
                             {name : The name of the resource}
                             {--module= : Name of module migration should belong to}
-                            {--collection : Create a resource collection}';
+                            {--collection : Create a resource collection}
+                            {--force : Create the class even if the component already exists}';
 
     /**
      * The console command description.
@@ -38,23 +39,17 @@ class ModuleMakeResourceCommand extends ModuleMakerCommand
 
         $name = $this->qualifyClass($module.'\\'.$folder.'\\'.$filename);
 
-        if ($this->files->exists($path = $this->getPath($name))) {
-            $this->logFileExist($name);
-
+        if (! $path = $this->getFilePath(name: $name, force: $this->option('force'))) {
             return true;
         }
 
         $type = '';
+
         if ($this->option('collection')) {
             $type = 'collection.';
         }
 
-        $this->setStubFile("resource.{$type}");
-        $this->makeDirectory($path);
-
-        $this->files->put($path, $this->buildClass($name));
-
-        $this->logFileCreated($name);
+        $this->generateFile($path, $name, $type);
 
         return null;
     }

--- a/src/Console/Commands/ModuleMakeSeederCommand.php
+++ b/src/Console/Commands/ModuleMakeSeederCommand.php
@@ -12,7 +12,8 @@ class ModuleMakeSeederCommand extends ModuleMakerCommand
     protected $signature = 'module:make:seeder
                 {name : The name of the seeder}
                 {--module= : Name of module seeder should belong to}
-                {--model= : The name of the model for the seeder}';
+                {--model= : The name of the model for the seeder}
+                {--force : Create the class even if the component already exists}';
 
     /**
      * The console command description.
@@ -34,36 +35,31 @@ class ModuleMakeSeederCommand extends ModuleMakerCommand
         $filename = $this->getNameInput();
         $folder = $this->getFolderPath();
 
-        $type = '';
-        if ($model = $this->option('model')) {
-            $model = $this->qualifyClass($module.'\\'.'Models'.'\\'.$model);
-        }
-
         $filename = $this->appendSuffix(filename: $filename);
 
         $name = $this->qualifyClass($module.'\\'.$folder.'\\'.$filename);
 
-        if ($this->files->exists($path = $this->getPath($name))) {
-            $this->logFileExist($name);
-
+        if (! $path = $this->getFilePath(name: $name, force: $this->option('force'))) {
             return true;
         }
 
-        $this->setStubFile("seeder.{$type}");
-        $this->makeDirectory($path);
+        $type = '';
 
-        $stub = $this->buildClass($name);
+        if ($model = $this->option('model')) {
+            $model = $this->qualifyClass($module.'\\'.'Models'.'\\'.$model);
 
-        if ($model) {
+            $this->setStubFile("seeder.{$type}");
+            $this->makeDirectory($path);
+
+            $stub = $this->buildClass($name);
             $this->files->put($path, $this->buildModel($stub, $model));
+
             $this->logFileCreated($name);
 
             return null;
         }
 
-        $this->files->put($path, $stub);
-
-        $this->logFileCreated($name);
+        $this->generateFile($path, $name, $type);
 
         return null;
     }

--- a/src/Console/Commands/ModuleMakeViewCommand.php
+++ b/src/Console/Commands/ModuleMakeViewCommand.php
@@ -38,21 +38,14 @@ class ModuleMakeViewCommand extends ModuleMakerCommand
 
         $name = $this->qualifyClass($module.'\\'.$folder.'\\'.$filename);
 
-        if ($this->files->exists($path = $this->getPath($name, 'blade.php')) && ! $this->option('force')) {
-            $this->logFileExist($path);
-
+        if (! $path = $this->getFilePath(name: $name, force: $this->option('force'))) {
             return true;
         }
 
         $type = '';
 
-        $this->setStubFile("view.{$type}");
-        $this->makeDirectory($path);
-        $this->files->put($path, $this->buildClass($name));
+        $this->generateFile($path, $name, $type);
 
-        $this->logFileCreated($name);
-
-        $folder = 'Tests/Feature';
         if ($this->option('pest')) {
             $this->call(
                 ModuleMakeTestCommand::class,
@@ -63,7 +56,6 @@ class ModuleMakeViewCommand extends ModuleMakerCommand
                     '--view' => true,
                 ]
             );
-            $type = 'pest.';
         }
 
         if ($this->option('test')) {
@@ -75,7 +67,6 @@ class ModuleMakeViewCommand extends ModuleMakerCommand
                     '--view' => true,
                 ]
             );
-            $type = 'test.';
         }
 
         return null;
@@ -84,5 +75,16 @@ class ModuleMakeViewCommand extends ModuleMakerCommand
     protected function getFolderPath(): string
     {
         return 'Views';
+    }
+
+    protected function getFilePath(string $name, bool $force = false): ?string
+    {
+        if ($this->files->exists($path = $this->getPath($name, 'blade.php')) && ! $force) {
+            $this->logFileExist($path);
+
+            return null;
+        }
+
+        return $path;
     }
 }


### PR DESCRIPTION
Some command classes use the base class's getFilePath() method for checking if a file already exists (ModuleMakeJobCommand), while others duplicate the file-existence logic inline with raw $this->files->exists() calls (ModuleMakeControllerCommand, ModuleMakeRequestCommand, ModuleMakeMiddlewareCommand, ModuleMakeNotificationCommand, etc.). The base class already provides getFilePath() which handles this cleanly.