### PR TITLE
Add interactive module selection with autocomplete prompt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "php": "^8.2",
         "illuminate/console": "^10.0|^11.0|^12.0",
         "illuminate/support": "^10.0|^11.0|^12.0",
-        "laravel/prompts": "^0.1"
+        "laravel/prompts": "^0.3"
     },
     "require-dev": {
         "laravel/pint": "^1.10",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "php": "^8.2",
         "illuminate/console": "^10.0|^11.0|^12.0",
         "illuminate/support": "^10.0|^11.0|^12.0",
-        "laravel/prompts": "^0.3"
+        "laravel/prompts": "^0.2|^0.3"
     },
     "require-dev": {
         "laravel/pint": "^1.10",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "php": "^8.2",
         "illuminate/console": "^10.0|^11.0|^12.0",
         "illuminate/support": "^10.0|^11.0|^12.0",
-        "laravel/prompts": "^0.2|^0.3"
+        "laravel/prompts": "^0.1|^0.3"
     },
     "require-dev": {
         "laravel/pint": "^1.10",

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
     "require": {
         "php": "^8.2",
         "illuminate/console": "^10.0|^11.0|^12.0",
-        "illuminate/support": "^10.0|^11.0|^12.0"
+        "illuminate/support": "^10.0|^11.0|^12.0",
+        "laravel/prompts": "^0.1"
     },
     "require-dev": {
         "laravel/pint": "^1.10",

--- a/src/Console/Commands/ModuleMakerCommand.php
+++ b/src/Console/Commands/ModuleMakerCommand.php
@@ -5,6 +5,7 @@ namespace NorbyBaru\Modularize\Console\Commands;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Str;
+use function Laravel\Prompts\suggest;
 
 abstract class ModuleMakerCommand extends GeneratorCommand
 {
@@ -35,7 +36,12 @@ abstract class ModuleMakerCommand extends GeneratorCommand
     public function getModuleInput(): string
     {
         if (! $this->module = $this->option('module')) {
-            $this->module = $this->ask('What is the name of the module?');
+            $this->module = suggest(
+                label: 'What is the name of the module?',
+                options: $this->getAvailableModules(),
+                placeholder: 'Start typing to search...',
+                required: true
+            );
         }
 
         return $this->module;

--- a/src/Console/Commands/ModuleMakerCommand.php
+++ b/src/Console/Commands/ModuleMakerCommand.php
@@ -402,5 +402,26 @@ abstract class ModuleMakerCommand extends GeneratorCommand
         return $this->type;
     }
 
+    /**
+     * Get all available modules in the project.
+     *
+     * @return array
+     */
+    protected function getAvailableModules(): array
+    {
+        $moduleRootPath = $this->getModuleRootPath();
+
+        if (! is_dir($moduleRootPath)) {
+            return [];
+        }
+
+        $moduleDirectories = array_map(
+            'class_basename',
+            $this->files->directories($moduleRootPath)
+        );
+
+        return $moduleDirectories;
+    }
+
     abstract protected function getFolderPath(): string;
 }

--- a/src/Console/Commands/ModuleMakerCommand.php
+++ b/src/Console/Commands/ModuleMakerCommand.php
@@ -5,6 +5,7 @@ namespace NorbyBaru\Modularize\Console\Commands;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Str;
+
 use function Laravel\Prompts\suggest;
 
 abstract class ModuleMakerCommand extends GeneratorCommand
@@ -410,8 +411,6 @@ abstract class ModuleMakerCommand extends GeneratorCommand
 
     /**
      * Get all available modules in the project.
-     *
-     * @return array
      */
     protected function getAvailableModules(): array
     {

--- a/tests/Commands/ModuleMakerCommandTest.php
+++ b/tests/Commands/ModuleMakerCommandTest.php
@@ -66,8 +66,6 @@ class ModuleMakerCommandTest extends MakeCommandTestCase
      * Call a protected method on an object using reflection.
      *
      * @param  object  $object
-     * @param  string  $methodName
-     * @param  array  $parameters
      * @return mixed
      */
     protected function callProtectedMethod($object, string $methodName, array $parameters = [])

--- a/tests/Commands/ModuleMakerCommandTest.php
+++ b/tests/Commands/ModuleMakerCommandTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace NorbyBaru\Modularize\Tests\Commands;
+
+use Illuminate\Support\Facades\File;
+use NorbyBaru\Modularize\Console\Commands\ModuleMakeControllerCommand;
+use NorbyBaru\Modularize\Tests\MakeCommandTestCase;
+use ReflectionClass;
+
+class ModuleMakerCommandTest extends MakeCommandTestCase
+{
+    public function test_it_returns_empty_array_when_no_modules_exist()
+    {
+        $this->cleanUp();
+
+        $command = $this->app->make(ModuleMakeControllerCommand::class);
+        $availableModules = $this->callProtectedMethod($command, 'getAvailableModules');
+
+        $this->assertIsArray($availableModules);
+        $this->assertEmpty($availableModules);
+    }
+
+    public function test_it_returns_available_modules()
+    {
+        // Create multiple test modules
+        $modules = ['Blog', 'Shop', 'User'];
+
+        foreach ($modules as $module) {
+            $modulePath = $this->getModulePath($module);
+            File::makeDirectory($modulePath, 0755, true);
+        }
+
+        $command = $this->app->make(ModuleMakeControllerCommand::class);
+        $availableModules = $this->callProtectedMethod($command, 'getAvailableModules');
+
+        $this->assertIsArray($availableModules);
+        $this->assertCount(3, $availableModules);
+        $this->assertContains('Blog', $availableModules);
+        $this->assertContains('Shop', $availableModules);
+        $this->assertContains('User', $availableModules);
+    }
+
+    public function test_it_returns_only_directories_as_modules()
+    {
+        // Create a test module directory
+        $modulePath = $this->getModulePath($this->moduleName);
+        File::makeDirectory($modulePath, 0755, true);
+
+        // Create a file in the root module path (should not be returned)
+        $rootPath = base_path(config('modularize.root_path'));
+        File::put("{$rootPath}/test-file.txt", 'test content');
+
+        $command = $this->app->make(ModuleMakeControllerCommand::class);
+        $availableModules = $this->callProtectedMethod($command, 'getAvailableModules');
+
+        $this->assertIsArray($availableModules);
+        $this->assertCount(1, $availableModules);
+        $this->assertContains($this->moduleName, $availableModules);
+        $this->assertNotContains('test-file.txt', $availableModules);
+
+        // Clean up
+        File::delete("{$rootPath}/test-file.txt");
+    }
+
+    /**
+     * Call a protected method on an object using reflection.
+     *
+     * @param  object  $object
+     * @param  string  $methodName
+     * @param  array  $parameters
+     * @return mixed
+     */
+    protected function callProtectedMethod($object, string $methodName, array $parameters = [])
+    {
+        $reflection = new ReflectionClass(get_class($object));
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $parameters);
+    }
+}


### PR DESCRIPTION
When the --module option is not provided, replace the basic $this->ask() prompt with Laravel's $this->anticipate() or $this->choice() to suggest existing module names from the modules directory.

You should package https://github.com/laravel/prompts. Laravel Prompts is a PHP package for adding beautiful and user-friendly forms to your command-line applications, with browser-like features including placeholder text and validation. 

See docs https://laravel.com/docs/12.x/prompts