### PR TITLE
Add summary output after module:make:model --all

### DIFF
--- a/src/Console/Commands/ModuleMakeModelCommand.php
+++ b/src/Console/Commands/ModuleMakeModelCommand.php
@@ -216,6 +216,32 @@ class ModuleMakeModelCommand extends ModuleMakerCommand
     }
 
     /**
+     * Display summary table of generated files.
+     *
+     * @return void
+     */
+    protected function displaySummaryTable(): void
+    {
+        if (empty($this->generatedFiles)) {
+            return;
+        }
+
+        $this->newLine();
+        $this->components->twoColumnDetail('<fg=gray>Generated Files</>', '<fg=gray>Details</>');
+        $this->newLine();
+
+        foreach ($this->generatedFiles as $file) {
+            $this->components->twoColumnDetail(
+                '<fg=green>'.$file['type'].'</>',
+                $file['path']
+            );
+        }
+
+        $this->newLine();
+        $this->components->info('Total files generated: '.count($this->generatedFiles));
+    }
+
+    /**
      * Get the console command arguments.
      *
      * @return array

--- a/src/Console/Commands/ModuleMakeModelCommand.php
+++ b/src/Console/Commands/ModuleMakeModelCommand.php
@@ -43,8 +43,6 @@ class ModuleMakeModelCommand extends ModuleMakerCommand
 
     /**
      * Track generated files for summary output.
-     *
-     * @var array
      */
     protected array $generatedFiles = [];
 
@@ -191,10 +189,6 @@ class ModuleMakeModelCommand extends ModuleMakerCommand
 
     /**
      * Override logFileCreated to track files for summary output.
-     *
-     * @param  string  $path
-     * @param  string|null  $type
-     * @return void
      */
     protected function logFileCreated(string $path, ?string $type = null): void
     {
@@ -204,10 +198,6 @@ class ModuleMakeModelCommand extends ModuleMakerCommand
 
     /**
      * Track a generated file for summary output.
-     *
-     * @param  string  $type
-     * @param  string  $path
-     * @return void
      */
     protected function trackGeneratedFile(string $type, string $path): void
     {
@@ -219,8 +209,6 @@ class ModuleMakeModelCommand extends ModuleMakerCommand
 
     /**
      * Display summary table of generated files.
-     *
-     * @return void
      */
     protected function displaySummaryTable(): void
     {

--- a/src/Console/Commands/ModuleMakeModelCommand.php
+++ b/src/Console/Commands/ModuleMakeModelCommand.php
@@ -188,6 +188,19 @@ class ModuleMakeModelCommand extends ModuleMakerCommand
     }
 
     /**
+     * Override logFileCreated to track files for summary output.
+     *
+     * @param  string  $path
+     * @param  string|null  $type
+     * @return void
+     */
+    protected function logFileCreated(string $path, ?string $type = null): void
+    {
+        $this->trackGeneratedFile($type ?? $this->type, $path);
+        parent::logFileCreated($path, $type);
+    }
+
+    /**
      * Track a generated file for summary output.
      *
      * @param  string  $type

--- a/src/Console/Commands/ModuleMakeModelCommand.php
+++ b/src/Console/Commands/ModuleMakeModelCommand.php
@@ -102,6 +102,8 @@ class ModuleMakeModelCommand extends ModuleMakerCommand
             $this->makeSeeder(name: $filename, module: $module);
         }
 
+        $this->displaySummaryTable();
+
         return null;
     }
 

--- a/src/Console/Commands/ModuleMakeModelCommand.php
+++ b/src/Console/Commands/ModuleMakeModelCommand.php
@@ -41,6 +41,13 @@ class ModuleMakeModelCommand extends ModuleMakerCommand
      */
     protected $type = 'Model';
 
+    /**
+     * Track generated files for summary output.
+     *
+     * @var array
+     */
+    protected array $generatedFiles = [];
+
     public function handle(): ?bool
     {
         $module = $this->getModuleInput();
@@ -178,6 +185,21 @@ class ModuleMakeModelCommand extends ModuleMakerCommand
     protected function setStubFile(string $file): void
     {
         $this->currentStub = $this->currentStub.$file.'sample';
+    }
+
+    /**
+     * Track a generated file for summary output.
+     *
+     * @param  string  $type
+     * @param  string  $path
+     * @return void
+     */
+    protected function trackGeneratedFile(string $type, string $path): void
+    {
+        $this->generatedFiles[] = [
+            'type' => $type,
+            'path' => $path,
+        ];
     }
 
     /**

--- a/tests/Commands/MakeModelCommandTest.php
+++ b/tests/Commands/MakeModelCommandTest.php
@@ -175,4 +175,25 @@ class MakeModelCommandTest extends MakeCommandTestCase
             ->expectsOutputToContain('--force')         // Verify --force suggestion is shown
             ->assertFailed();
     }
+
+    public function test_it_displays_summary_table_with_all_option()
+    {
+        $this->artisan(
+            command: 'module:make:model',
+            parameters: [
+                'name' => 'Product',
+                '--module' => $this->moduleName,
+                '--all' => true,
+            ]
+        )
+            ->expectsOutputToContain('Generated Files')
+            ->expectsOutputToContain('Total files generated:')
+            ->assertSuccessful();
+
+        // Verify files were actually created
+        $this->assertFileExists(filename: $this->getModulePath().'/Models/Product.php');
+        $this->assertMigrationFile(module: $this->moduleName, migrationFilename: 'create_products_table.php');
+        $this->assertFactoryFile(module: $this->moduleName, filename: 'ProductFactory');
+        $this->assertSeederFile(module: $this->moduleName, filename: 'ProductSeeder');
+    }
 }


### PR DESCRIPTION
When using the --all flag on module:make:model, display a consolidated summary table of all generated files at the end instead of scattered individual success messages.